### PR TITLE
fix: Change Docker CMD to use python -m uvicorn

### DIFF
--- a/academichub/.github/workflows/main.yml
+++ b/academichub/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.12'
+        python-version: '3.12' 
         cache: 'pip' # Cache pip dependencies
 
     - name: Install dependencies

--- a/academichub/Dockerfile
+++ b/academichub/Dockerfile
@@ -21,10 +21,6 @@ COPY . .
 # Expose the port the app runs on
 EXPOSE 8000
 
-# Set PYTHONPATH to include the /app directory (where src is located)
-ENV PYTHONPATH="/app:${PYTHONPATH}"
-
 # Define the command to run the application
-# This command will be used if `docker run` is used without a command.
-# For docker-compose, the command there might override this.
-CMD ["uvicorn", "src.main:app", "--host", "0.0.0.0", "--port", "8000"]
+# Using "python -m uvicorn" is often more robust for module discovery.
+CMD ["python", "-m", "uvicorn", "src.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/academichub/README.md
+++ b/academichub/README.md
@@ -83,7 +83,7 @@ Before you begin, ensure you have the following installed:
 
 1.  **Clone the repository:**
     ```bash
-    git clone <repository_url>
+    git clone <repository_url> 
     # Replace <repository_url> with the actual URL of the repository
     ```
 2.  **Navigate to the project directory:**

--- a/academichub/README_pt-BR.md
+++ b/academichub/README_pt-BR.md
@@ -83,7 +83,7 @@ Antes de começar, certifique-se de que possui o seguinte instalado:
 
 1.  **Clone o repositório:**
     ```bash
-    git clone <repository_url>
+    git clone <repository_url> 
     # Substitua <repository_url> pela URL real do repositório
     ```
 2.  **Navegue até o diretório do projeto:**

--- a/academichub/docker-compose.yml
+++ b/academichub/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       # This allows for live reloading of code changes.
       # Note: /app is the WORKDIR specified in the Dockerfile.
       - ./src:/app/src
-    command: uvicorn src.main:app --host 0.0.0.0 --port 8000 --reload
+    command: python -m uvicorn src.main:app --host 0.0.0.0 --port 8000 --reload
     # Environment variables can be set here if needed, e.g.:
     # environment:
     #   - MY_VARIABLE=my_value

--- a/academichub/docs/technical_decisions/template_decision_record.tex
+++ b/academichub/docs/technical_decisions/template_decision_record.tex
@@ -11,7 +11,7 @@
 \geometry{a4paper, margin=1in} % Example page geometry
 
 % Placeholder for IEEE specific commands or packages if known/needed later
-% \usepackage{IEEEtran}
+% \usepackage{IEEEtran} 
 
 % Document metadata placeholders
 \title{Technical Decision Record: [Decision Title]}

--- a/academichub/src/application/api.py
+++ b/academichub/src/application/api.py
@@ -54,7 +54,7 @@ async def update_lifecycle_stage(stage_name: str, updated_stage_data: LifecycleS
         if s.name == stage_name:
             stage_index = i
             break
-
+    
     if stage_index == -1:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -69,7 +69,7 @@ async def update_lifecycle_stage(stage_name: str, updated_stage_data: LifecycleS
                     status_code=status.HTTP_409_CONFLICT,
                     detail=f"Lifecycle stage with name '{updated_stage_data.name}' already exists. Cannot rename."
                 )
-
+    
     db_stages[stage_index] = updated_stage_data
     return db_stages[stage_index]
 
@@ -83,12 +83,12 @@ async def delete_lifecycle_stage(stage_name: str):
         if s.name == stage_name:
             stage_index = i
             break
-
+            
     if stage_index == -1:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Lifecycle stage with name '{stage_name}' not found."
         )
-
+        
     db_stages.pop(stage_index)
     return # For 204 No Content, FastAPI expects no body

--- a/academichub/tests/application/test_api.py
+++ b/academichub/tests/application/test_api.py
@@ -53,7 +53,7 @@ async def test_create_lifecycle_stage_success():
     new_stage_data = {"name": "Entrevista", "owner": "Hiring Manager"}
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
         response = await ac.post("/opportunities/lifecycle/stages/", json=new_stage_data)
-
+    
     assert response.status_code == 201
     created_stage = response.json()
     assert created_stage["name"] == new_stage_data["name"]
@@ -85,10 +85,10 @@ async def test_create_lifecycle_stage_invalid_payload():
 async def test_update_lifecycle_stage_success_change_owner():
     stage_to_update_name = "Application"
     update_data = {"name": "Application", "owner": "Recruiter"} # Changing owner
-
+    
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
         response = await ac.put(f"/opportunities/lifecycle/stages/{stage_to_update_name}", json=update_data)
-
+    
     assert response.status_code == 200
     updated_stage = response.json()
     assert updated_stage["name"] == update_data["name"]
@@ -105,10 +105,10 @@ async def test_update_lifecycle_stage_success_change_owner():
 async def test_update_lifecycle_stage_success_rename():
     stage_to_update_name = "Avaliação"
     update_data = {"name": "Technical Assessment", "owner": "University"} # Renaming
-
+    
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
         response = await ac.put(f"/opportunities/lifecycle/stages/{stage_to_update_name}", json=update_data)
-
+        
     assert response.status_code == 200
     updated_stage = response.json()
     assert updated_stage["name"] == update_data["name"]
@@ -125,11 +125,11 @@ async def test_update_lifecycle_stage_success_rename():
 async def test_update_lifecycle_stage_rename_conflict():
     stage_to_update_name = "Avaliação"
     # Try to rename "Avaliação" to "Descoberta", which already exists
-    update_data = {"name": "Descoberta", "owner": "University"}
-
+    update_data = {"name": "Descoberta", "owner": "University"} 
+    
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
         response = await ac.put(f"/opportunities/lifecycle/stages/{stage_to_update_name}", json=update_data)
-
+    
     assert response.status_code == 409
     assert "already exists" in response.json()["detail"]
 
@@ -137,7 +137,7 @@ async def test_update_lifecycle_stage_rename_conflict():
 async def test_update_lifecycle_stage_not_found():
     non_existent_name = "NonExistentStage"
     update_data = {"name": "NonExistentStage", "owner": "Nobody"}
-
+    
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
         response = await ac.put(f"/opportunities/lifecycle/stages/{non_existent_name}", json=update_data)
     assert response.status_code == 404
@@ -146,7 +146,7 @@ async def test_update_lifecycle_stage_not_found():
 async def test_update_lifecycle_stage_invalid_payload():
     stage_to_update_name = "Application"
     invalid_payload = {"owner": "Only Owner"} # Missing name
-
+    
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
         response = await ac.put(f"/opportunities/lifecycle/stages/{stage_to_update_name}", json=invalid_payload)
     assert response.status_code == 422
@@ -154,7 +154,7 @@ async def test_update_lifecycle_stage_invalid_payload():
 @pytest.mark.asyncio
 async def test_delete_lifecycle_stage_success():
     stage_to_delete_name = "Feedback"
-
+    
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
         response = await ac.delete(f"/opportunities/lifecycle/stages/{stage_to_delete_name}")
     assert response.status_code == 204
@@ -177,7 +177,7 @@ async def test_delete_lifecycle_stage_not_found():
 @pytest.fixture
 def fresh_db_stages():
     original_stages = [LifecycleStage(**data) for data in DEFAULT_STAGES_DATA]
-
+    
     # Monkeypatch api_db_stages for the duration of a test
     # This is a bit more involved if api_db_stages is imported directly
     # For simplicity, the global fixture `reset_db_stages` is used for all tests.
@@ -205,10 +205,10 @@ async def test_get_opportunity_lifecycle_model_validation():
 async def test_update_lifecycle_stage_success_no_rename():
     stage_to_update_name = "Application"
     update_data = {"name": "Application", "owner": "New Owner For Application"}
-
+    
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
         response = await ac.put(f"/opportunities/lifecycle/stages/{stage_to_update_name}", json=update_data)
-
+    
     assert response.status_code == 200
     updated_stage = response.json()
     assert updated_stage["name"] == update_data["name"]
@@ -225,10 +225,10 @@ async def test_update_lifecycle_stage_success_no_rename():
 async def test_update_lifecycle_stage_rename_to_self_allowed():
     stage_to_update_name = "Application"
     update_data = {"name": "Application", "owner": "Owner Updated Again"} # name is same as path param
-
+    
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
         response = await ac.put(f"/opportunities/lifecycle/stages/{stage_to_update_name}", json=update_data)
-
+        
     assert response.status_code == 200
     updated_stage = response.json()
     assert updated_stage["name"] == stage_to_update_name

--- a/academichub/tests/domain/test_models.py
+++ b/academichub/tests/domain/test_models.py
@@ -29,7 +29,7 @@ class TestOpportunityLifecycle:
     def test_create_opportunity_lifecycle_default_stages(self):
         lifecycle = OpportunityLifecycle()
         assert len(lifecycle.stages) == 4
-
+        
         expected_stages = [
             {"name": "Descoberta", "owner": "AI Agent"},
             {"name": "Application", "owner": "Student"},
@@ -48,7 +48,7 @@ class TestOpportunityLifecycle:
             {"name": "Custom 2", "owner": "Owner 2"},
         ]
         custom_stages = [LifecycleStage(**data) for data in custom_stages_data]
-
+        
         lifecycle = OpportunityLifecycle(stages=custom_stages)
         assert len(lifecycle.stages) == 2
         assert lifecycle.stages[0].name == "Custom 1"


### PR DESCRIPTION
This commit modifies how the Uvicorn server is launched within the Docker container to resolve persistent ModuleNotFoundError issues.

- Updated `Dockerfile` to remove the `ENV PYTHONPATH` directive and changed the `CMD` to `["python", "-m", "uvicorn", "src.main:app", "--host", "0.0.0.0", "--port", "8000"]`.
- Updated `docker-compose.yml` to change the `command` for the backend service to `python -m uvicorn src.main:app --host 0.0.0.0 --port 8000 --reload`.

Using `python -m uvicorn` is a more robust method for Python module discovery within containers and should correctly resolve paths for the application modules. No changes to user-facing README commands were necessary.